### PR TITLE
Fix error `strpos(): Empty needle`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "sail/useragent",
+    "name": "justin-oh/useragent",
     "description": "Library to detect the browser and all its info (OS, Platform, ...)",
     "keywords":["useragent","browser-detection"],
     "homepage": "http://github.com/rainphp/useragent",

--- a/src/Sail/Parser/Simple/OS/Windows.php
+++ b/src/Sail/Parser/Simple/OS/Windows.php
@@ -22,7 +22,7 @@ class Windows{
             'XBLWP7'               => 'Windows Phone 7',
             'Windows NT 6.0'       => 'Windows Vista',
             'Windows NT 5.1'       => 'Windows XP',
-            ''                     => 'Other Windows',
+            ' '                     => 'Other Windows',
     );
     
     public static function parse($ua) {


### PR DESCRIPTION
The empty string is eventually passed to `strpos` which causes an error. Updating the empty string to a single space avoids this error.